### PR TITLE
fix: restore User and Message models, fix circular import

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,32 @@
 from datetime import datetime
-from app import db
+from __init__ import db
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
 
+
+# ── User ──────────────────────────────────────────────────────────
+class User(UserMixin, db.Model):
+    __tablename__ = 'users'
+
+    id         = db.Column(db.Integer, primary_key=True)
+    name       = db.Column(db.String(100), nullable=False)
+    email      = db.Column(db.String(150), unique=True, nullable=False)
+    password   = db.Column(db.String(256), nullable=False)
+    course     = db.Column(db.String(150))
+    bio        = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def set_password(self, raw_password):
+        self.password = generate_password_hash(raw_password)
+
+    def check_password(self, raw_password):
+        return check_password_hash(self.password, raw_password)
+
+    def __repr__(self):
+        return f'<User {self.email}>'
+
+
+# ── Skill ─────────────────────────────────────────────────────────
 class Skill(db.Model):
     __tablename__ = 'skills'
 
@@ -8,32 +34,53 @@ class Skill(db.Model):
     user_id     = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     name        = db.Column(db.String(100), nullable=False)
     category    = db.Column(db.String(50),  nullable=False)
-    level       = db.Column(db.String(20))   # Beginner / Intermediate / Expert
+    level       = db.Column(db.String(20))
     description = db.Column(db.Text)
     created_at  = db.Column(db.DateTime, default=datetime.utcnow)
 
-    # lets you write skill.owner.username in templates
     owner    = db.relationship('User', backref='skills', lazy=True)
-    requests = db.relationship('Request', backref='skill', lazy=True, cascade='all, delete-orphan')
+    requests = db.relationship('Request', backref='skill', lazy=True,
+                               cascade='all, delete-orphan')
 
     def to_dict(self):
         return {
-            'id': self.id, 'name': self.name,
-            'category': self.category, 'level': self.level,
+            'id':          self.id,
+            'name':        self.name,
+            'category':    self.category,
+            'level':       self.level,
             'description': self.description
         }
 
 
+# ── Request ───────────────────────────────────────────────────────
 class Request(db.Model):
     __tablename__ = 'requests'
 
-    id          = db.Column(db.Integer, primary_key=True)
-    skill_id    = db.Column(db.Integer, db.ForeignKey('skills.id'),  nullable=False)
-    from_user_id= db.Column(db.Integer, db.ForeignKey('users.id'),   nullable=False)
-    to_user_id  = db.Column(db.Integer, db.ForeignKey('users.id'),   nullable=False)
-    message     = db.Column(db.Text)
-    status      = db.Column(db.String(20), default='pending')  # pending/accepted/rejected
-    created_at  = db.Column(db.DateTime, default=datetime.utcnow)
+    id           = db.Column(db.Integer, primary_key=True)
+    skill_id     = db.Column(db.Integer, db.ForeignKey('skills.id'),  nullable=False)
+    from_user_id = db.Column(db.Integer, db.ForeignKey('users.id'),   nullable=False)
+    to_user_id   = db.Column(db.Integer, db.ForeignKey('users.id'),   nullable=False)
+    message      = db.Column(db.Text)
+    status       = db.Column(db.String(20), default='pending')
+    created_at   = db.Column(db.DateTime, default=datetime.utcnow)
 
-    from_user = db.relationship('User', foreign_keys=[from_user_id], backref='sent_requests')
-    to_user   = db.relationship('User', foreign_keys=[to_user_id],   backref='received_requests')
+    from_user = db.relationship('User', foreign_keys=[from_user_id],
+                                backref='sent_requests')
+    to_user   = db.relationship('User', foreign_keys=[to_user_id],
+                                backref='received_requests')
+
+
+# ── Message ───────────────────────────────────────────────────────
+class Message(db.Model):
+    __tablename__ = 'messages'
+
+    id          = db.Column(db.Integer, primary_key=True)
+    sender_id   = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    receiver_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    body        = db.Column(db.Text, nullable=False)
+    timestamp   = db.Column(db.DateTime, default=datetime.utcnow)
+
+    sender   = db.relationship('User', foreign_keys=[sender_id],
+                               backref='sent_messages')
+    receiver = db.relationship('User', foreign_keys=[receiver_id],
+                               backref='received_messages')


### PR DESCRIPTION
## What's changed

### models.py
- Restored User model with name, email, password, course, bio fields
- Added password hashing via werkzeug (set_password / check_password)
- Added Message model with sender, receiver, body, timestamp fields
- Fixed circular import: replaced `from app import db` with `from __init__ import db`
- Kept existing Skill and Request models unchanged


## Tables in database
- users
- skills
- requests
- messages