### PR TITLE
feat: connect requests page to database with accept and decline

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,87 @@
-from flask import render_template, redirect, url_for, request, jsonify, flash
+from flask import Flask, render_template, redirect, url_for, request, jsonify, flash
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
-from _init_ import create_app, db
+from __init__ import create_app, db
 from models import User, Skill, Request, Message
 
 app = create_app()
 
+# ── Flask-Login ───────────────────────────────────────────────────
+login_manager = LoginManager()
+login_manager.init_app(app)
+login_manager.login_view = 'login'
 
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+# ── Create tables ─────────────────────────────────────────────────
+with app.app_context():
+    db.create_all()
+
+# ── Home ──────────────────────────────────────────────────────────
+@app.route('/')
+def index():
+    if current_user.is_authenticated:
+        return redirect(url_for('skills'))
+    return render_template('index.html')
+
+# ── Signup ────────────────────────────────────────────────────────
+@app.route('/signup', methods=['GET', 'POST'])
+def signup():
+    if current_user.is_authenticated:
+        return redirect(url_for('skills'))
+
+    if request.method == 'POST':
+        name     = request.form.get('name', '').strip()
+        email    = request.form.get('email', '').strip().lower()
+        password = request.form.get('password', '')
+        course   = request.form.get('course', '').strip()
+        bio      = request.form.get('bio', '').strip()
+
+        if not name or not email or not password:
+            return render_template('signup.html',
+                                   error='Name, email and password are required.')
+        if len(password) < 6:
+            return render_template('signup.html',
+                                   error='Password must be at least 6 characters.')
+        if User.query.filter_by(email=email).first():
+            return render_template('signup.html',
+                                   error='An account with that email already exists.')
+
+        user = User(name=name, email=email, course=course, bio=bio)
+        user.set_password(password)
+        db.session.add(user)
+        db.session.commit()
+        login_user(user)
+        return redirect(url_for('skills'))
+
+    return render_template('signup.html')
+
+# ── Login ─────────────────────────────────────────────────────────
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for('skills'))
+
+    if request.method == 'POST':
+        email    = request.form.get('email', '').strip().lower()
+        password = request.form.get('password', '')
+        user     = User.query.filter_by(email=email).first()
+
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('skills'))
+
+        return render_template('login.html', error='Invalid email or password.')
+
+    return render_template('login.html')
+
+# ── Logout ────────────────────────────────────────────────────────
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
 
 # ── Skills ────────────────────────────────────────────────────────
 @app.route('/skills')
@@ -19,138 +95,158 @@ def skills():
 def create_skill():
     data  = request.get_json()
     skill = Skill(
-        title       = data.get('title'),
+        name        = data.get('name'),
         category    = data.get('category'),
         description = data.get('description'),
         user_id     = current_user.id
     )
     db.session.add(skill)
     db.session.commit()
-    return jsonify({ 'status': 'ok', 'id': skill.id })
+    return jsonify({'status': 'ok', 'id': skill.id})
 
 @app.route('/skills/delete/<int:skill_id>', methods=['POST'])
 @login_required
 def delete_skill(skill_id):
     skill = Skill.query.get_or_404(skill_id)
     if skill.user_id != current_user.id:
-        return jsonify({ 'status': 'error', 'message': 'Unauthorized' }), 403
+        return jsonify({'status': 'error', 'message': 'Unauthorized'}), 403
     db.session.delete(skill)
     db.session.commit()
-    return jsonify({ 'status': 'ok' })
+    return jsonify({'status': 'ok'})
 
-    # ── Register your skills blueprint ──────────────────────────
-    from routes.skills import skills_bp
-    app.register_blueprint(skills_bp)
+# ── Requests ──────────────────────────────────────────────────────
+@app.route('/requests')
+@login_required
+def requests_page():
+    incoming = Request.query.filter_by(
+        to_user_id=current_user.id
+    ).order_by(Request.created_at.desc()).all()
 
-    # ── Existing Routes ──────────────────────────────────────────
-    @app.route('/')
-    def index():
-        return render_template('index.html')
+    outgoing = Request.query.filter_by(
+        from_user_id=current_user.id
+    ).order_by(Request.created_at.desc()).all()
 
-    @app.route('/requests')
-    def requests():
-        return render_template('requests.html')
+    return render_template('requests.html', incoming=incoming, outgoing=outgoing)
 
-    # ── Chat Routes ──────────────────────────────────────────────
-    @app.route('/chat')
-    def chat():
-        return render_template('chat.html', connections=connections)
+@app.route('/requests/accept/<int:request_id>', methods=['POST'])
+@login_required
+def accept_request(request_id):
+    req = Request.query.get_or_404(request_id)
+    if req.to_user_id != current_user.id:
+        return jsonify({'status': 'error'}), 403
+    req.status = 'accepted'
+    db.session.commit()
+    return redirect(url_for('requests_page'))
 
-    @app.route('/chat/messages/<int:user_id>', methods=['GET'])
-    def get_messages(user_id):
-        msgs = messages_store.get(user_id, [])
-        formatted = []
-        for m in msgs:
-            formatted.append({
-                'type': 'sent' if m['sender'] == CURRENT_USER else 'received',
-                'text': m['text']
-            })
-        return jsonify({ 'messages': formatted })
+@app.route('/requests/decline/<int:request_id>', methods=['POST'])
+@login_required
+def decline_request(request_id):
+    req = Request.query.get_or_404(request_id)
+    if req.to_user_id != current_user.id:
+        return jsonify({'status': 'error'}), 403
+    req.status = 'declined'
+    db.session.commit()
+    return redirect(url_for('requests_page'))
 
-    @app.route('/chat/send', methods=['POST'])
-    def send_message():
-        data    = request.get_json()
-        user_id = data.get('user_id')
-        text    = data.get('message', '').strip()
+# ── Chat ──────────────────────────────────────────────────────────
+@app.route('/chat')
+@login_required
+def chat():
+    accepted = Request.query.filter(
+        ((Request.from_user_id == current_user.id) |
+         (Request.to_user_id   == current_user.id)),
+        Request.status == 'accepted'
+    ).all()
 
-        if not text or not user_id:
-            return jsonify({ 'status': 'error', 'message': 'Missing data' }), 400
+    connections = []
+    seen = set()
+    for req in accepted:
+        other = req.from_user if req.to_user_id == current_user.id else req.to_user
+        if other.id not in seen:
+            seen.add(other.id)
+            connections.append(other)
 
-        if user_id not in messages_store:
-            messages_store[user_id] = []
-        messages_store[user_id].append({ 'sender': CURRENT_USER, 'text': text })
-        return jsonify({ 'status': 'ok' })
+    return render_template('chat.html', connections=connections)
 
-    # ── Profile Routes ───────────────────────────────────────────
-    @app.route('/profile')
-    def profile():
-        return render_template('profile.html')
+@app.route('/chat/messages/<int:user_id>', methods=['GET'])
+@login_required
+def get_messages(user_id):
+    msgs = Message.query.filter(
+        ((Message.sender_id   == current_user.id) &
+         (Message.receiver_id == user_id)) |
+        ((Message.sender_id   == user_id) &
+         (Message.receiver_id == current_user.id))
+    ).order_by(Message.timestamp.asc()).all()
 
-    @app.route('/profile/skills/add', methods=['POST'])
-    def add_skill():
-        data = request.get_json()
-        return jsonify({ 'status': 'ok' })
+    formatted = [{
+        'type': 'sent' if m.sender_id == current_user.id else 'received',
+        'text': m.body
+    } for m in msgs]
 
-    @app.route('/profile/skills/edit/<int:skill_id>', methods=['POST'])
-    def edit_skill(skill_id):
-        data = request.get_json()
-        return jsonify({ 'status': 'ok' })
+    return jsonify({'messages': formatted})
 
-    @app.route('/profile/skills/delete/<int:skill_id>', methods=['POST'])
-    def delete_skill(skill_id):
-        return jsonify({ 'status': 'ok' })
+@app.route('/chat/send', methods=['POST'])
+@login_required
+def send_message():
+    data    = request.get_json()
+    user_id = data.get('user_id')
+    text    = data.get('message', '').strip()
+    if not text or not user_id:
+        return jsonify({'status': 'error'}), 400
+    msg = Message(
+        sender_id=current_user.id,
+        receiver_id=int(user_id),
+        body=text
+    )
+    db.session.add(msg)
+    db.session.commit()
+    return jsonify({'status': 'ok'})
 
-    # ── Login / Signup Routes ────────────────────────────────────
-    @app.route('/signup', methods=['GET', 'POST'])
-    def signup():
-        if request.method == 'POST':
-            name     = request.form.get('name')
-            email    = request.form.get('email')
-            password = request.form.get('password')
-            course   = request.form.get('course')
-            bio      = request.form.get('bio')
+# ── Profile ───────────────────────────────────────────────────────
+@app.route('/profile')
+@login_required
+def profile():
+    user_skills = Skill.query.filter_by(
+        user_id=current_user.id
+    ).order_by(Skill.created_at.desc()).all()
+    return render_template('profile.html', user=current_user, skills=user_skills)
 
-            existing = next((u for u in users if u['email'] == email), None)
-            if existing:
-                return render_template('signup.html',
-                                       error='An account with that email already exists.')
+@app.route('/profile/skills/add', methods=['POST'])
+@login_required
+def add_skill():
+    data  = request.get_json()
+    skill = Skill(
+        name        = data.get('name'),
+        category    = data.get('category'),
+        description = data.get('desc'),
+        user_id     = current_user.id
+    )
+    db.session.add(skill)
+    db.session.commit()
+    return jsonify({'status': 'ok', 'id': skill.id})
 
-            users.append({ 'name': name, 'email': email,
-                           'password': password, 'course': course, 'bio': bio })
-            return redirect(url_for('login'))
+@app.route('/profile/skills/edit/<int:skill_id>', methods=['POST'])
+@login_required
+def edit_skill(skill_id):
+    skill = Skill.query.get_or_404(skill_id)
+    if skill.user_id != current_user.id:
+        return jsonify({'status': 'error'}), 403
+    data              = request.get_json()
+    skill.name        = data.get('name')
+    skill.category    = data.get('category')
+    skill.description = data.get('desc')
+    db.session.commit()
+    return jsonify({'status': 'ok'})
 
-        return render_template('signup.html')
-
-    @app.route('/login', methods=['GET', 'POST'])
-    def login():
-        if request.method == 'POST':
-            email    = request.form.get('email')
-            password = request.form.get('password')
-            user     = next((u for u in users
-                             if u['email'] == email and u['password'] == password), None)
-            if user:
-                session['user']  = user['name']
-                session['email'] = user['email']
-                return redirect(url_for('skills.skills'))
-            else:
-                return render_template('login.html', error='Invalid email or password.')
-
-        return render_template('login.html')
-
-    @app.route('/logout')
-    def logout():
-        session.clear()
-        return redirect(url_for('login'))
-
-    # ── Create tables ────────────────────────────────────────────
-    with app.app_context():
-        import models
-        db.create_all()
-
-    return app
-
-
-app = create_app()
+@app.route('/profile/skills/delete/<int:skill_id>', methods=['POST'])
+@login_required
+def profile_delete_skill(skill_id):
+    skill = Skill.query.get_or_404(skill_id)
+    if skill.user_id != current_user.id:
+        return jsonify({'status': 'error'}), 403
+    db.session.delete(skill)
+    db.session.commit()
+    return jsonify({'status': 'ok'})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -14,55 +14,79 @@
         💬 Accepted users can chat with you on the Chat page.
     </div>
 
-    <div class="request-card mb-3">
-        <div class="d-flex justify-content-between align-items-center">
-            <div>
-                <h5 class="mb-1 fw-semibold">Python Programming</h5>
-                <p class="text-muted mb-2 small">Requested by Sara Ali</p>
-                <span class="badge-accepted">Accepted</span>
-            </div>
-            <button class="btn-can-chat">💬 Can Chat</button>
-        </div>
-    </div>
+    <!-- Flash Messages -->
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="flash flash-{{ category }} mb-3">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
 
+    <!-- Incoming Requests -->
+    <h4 class="fw-semibold mb-3">Incoming Requests</h4>
+
+    {% for req in incoming %}
     <div class="request-card mb-3">
         <div class="d-flex justify-content-between align-items-center">
             <div>
-                <h5 class="mb-1 fw-semibold">UI/UX Design</h5>
-                <p class="text-muted mb-2 small">Requested by Tom Wilson</p>
-                <span class="badge-pending">Pending</span>
+                <h5 class="mb-1 fw-semibold">{{ req.skill.name }}</h5>
+                <p class="text-muted mb-2 small">Requested by {{ req.from_user.name }}</p>
+                {% if req.status == 'accepted' %}
+                    <span class="badge-accepted">Accepted</span>
+                {% elif req.status == 'declined' %}
+                    <span class="badge-declined">Declined</span>
+                {% else %}
+                    <span class="badge-pending">Pending</span>
+                {% endif %}
             </div>
+
             <div class="d-flex gap-2">
-                <button class="btn-accept">✔ Accept</button>
-                <button class="btn-decline">✘ Decline</button>
+                {% if req.status == 'accepted' %}
+                    <a href="{{ url_for('chat') }}" class="btn-can-chat">💬 Can Chat</a>
+                {% elif req.status == 'pending' %}
+                    <form method="POST" action="{{ url_for('accept_request', request_id=req.id) }}">
+                        <button type="submit" class="btn-accept">✔ Accept</button>
+                    </form>
+                    <form method="POST" action="{{ url_for('decline_request', request_id=req.id) }}">
+                        <button type="submit" class="btn-decline">✘ Decline</button>
+                    </form>
+                {% endif %}
             </div>
         </div>
+        {% if req.message %}
+        <p class="text-muted small mt-2 mb-0"><em>"{{ req.message }}"</em></p>
+        {% endif %}
     </div>
+    {% else %}
+    <p class="text-muted mb-4">No incoming requests yet.</p>
+    {% endfor %}
 
+    <!-- Outgoing Requests -->
+    <h4 class="fw-semibold mb-3 mt-4">Sent Requests</h4>
+
+    {% for req in outgoing %}
     <div class="request-card mb-3">
         <div class="d-flex justify-content-between align-items-center">
             <div>
-                <h5 class="mb-1 fw-semibold">Guitar</h5>
-                <p class="text-muted mb-2 small">Requested by Jake Lee</p>
-                <span class="badge-accepted">Accepted</span>
+                <h5 class="mb-1 fw-semibold">{{ req.skill.name }}</h5>
+                <p class="text-muted mb-2 small">Sent to {{ req.to_user.name }}</p>
+                {% if req.status == 'accepted' %}
+                    <span class="badge-accepted">Accepted</span>
+                {% elif req.status == 'declined' %}
+                    <span class="badge-declined">Declined</span>
+                {% else %}
+                    <span class="badge-pending">Pending</span>
+                {% endif %}
             </div>
-            <button class="btn-can-chat">💬 Can Chat</button>
+            {% if req.status == 'accepted' %}
+            <a href="{{ url_for('chat') }}" class="btn-can-chat">💬 Can Chat</a>
+            {% endif %}
         </div>
     </div>
+    {% else %}
+    <p class="text-muted">You haven't sent any requests yet.</p>
+    {% endfor %}
 
-    <div class="request-card mb-3">
-        <div class="d-flex justify-content-between align-items-center">
-            <div>
-                <h5 class="mb-1 fw-semibold">Public Speaking</h5>
-                <p class="text-muted mb-2 small">Requested by Lena Park</p>
-                <span class="badge-pending">Pending</span>
-            </div>
-            <div class="d-flex gap-2">
-                <button class="btn-accept">✔ Accept</button>
-                <button class="btn-decline">✘ Decline</button>
-            </div>
-        </div>
-    </div>
 </div>
-
 {% endblock %}


### PR DESCRIPTION
## What's changed

### app.py
- Fixed broken structure: all routes after delete_skill were dead code
  (trapped inside the function body), now all routes are at top level
- Fixed import: from _init_ → from __init__
- Restored all routes: home, signup, login, logout, skills, requests,
  chat, profile
- Added login_required to all protected routes

### templates/requests.html
- Removed all hardcoded dummy data
- Connected to real database via incoming and outgoing request objects
- Incoming requests: shows skill name, requester name, Accept / Decline buttons
- Outgoing requests: shows skill name, recipient name, current status
- Accepted requests show "Can Chat" button linking to chat page
- Flash messages displayed for user feedback

## Pages covered
- `/requests` — view incoming and outgoing skill requests
- `/requests/accept/<id>` — accept a request
- `/requests/decline/<id>` — decline a request