### PR TITLE
fix: display incoming and outgoing request lists on requests page

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,7 +107,12 @@ def requests_page():
     incoming = Request.query.filter_by(
         to_user_id=current_user.id
     ).order_by(Request.created_at.desc()).all()
-    return render_template('requests.html', requests=incoming)
+
+    outgoing = Request.query.filter_by(
+        from_user_id=current_user.id
+    ).order_by(Request.created_at.desc()).all()
+
+    return render_template('requests.html', incoming=incoming, outgoing=outgoing)
 
 @app.route('/requests/send/<int:skill_id>', methods=['POST'])
 @login_required


### PR DESCRIPTION
Fixed requests_page() to query and pass both incoming and outgoing requests separately to the template, resolving the issue where the page always displayed the empty state due to a variable name mismatch.