### PR TITLE
Adjust navbar brand alignment

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -14,6 +14,13 @@ body {
 .navbar-brand {
   font-size: 18px;
   letter-spacing: -0.2px;
+  margin-left: clamp(0px, 10vw, 210px);
+}
+
+@media (max-width: 991.98px) {
+  .navbar-brand {
+    margin-left: 0;
+  }
 }
 
 .nav-link {


### PR DESCRIPTION
Fix the SkillSwap logo/brand in the navbar sits too far on the left on some pages compared to others.