### PR TITLE
Fix/csrf chat requests

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -103,6 +103,9 @@ function sendMessage() {
     url: '/chat/send',
     method: 'POST',
     contentType: 'application/json',
+    headers: {
+    'X-CSRFToken': window.csrfToken
+    },
     data: JSON.stringify({
       user_id: currentUserId,
       message: text

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -76,6 +76,7 @@
 {% block scripts %}
 <script>
   window.initialChatUserId = {{ active_user_id|tojson }};
+  window.csrfToken = "{{ csrf_token() }}";
 </script>
 <script src="{{ url_for('static', filename='js/chat.js') }}"></script>
 {% endblock %}

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -141,7 +141,10 @@ document.addEventListener('DOMContentLoaded', function () {
             if (targetId === 'sent-section') {
                 fetch("{{ url_for('mark_sent_requests_seen') }}", {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': "{{ csrf_token() }}"
+                    },
                     body: JSON.stringify({ seen: true })
                 }).then(function () {
                     const dot = document.querySelector('.nav-request-dot');


### PR DESCRIPTION
Fixes #101
Changes Made
Added CSRF token injection in chat template
Added X-CSRFToken header to chat AJAX requests
Added CSRF token support for requests page fetch calls
Fixed /chat/send 400 Bad Request error
Fixed /requests/mark-sent-seen CSRF validation failure