### PR TITLE
fix: enforce SECRET_KEY env variable and disable hardcoded debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,4 +80,4 @@ with app.app_context():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=os.environ.get("FLASK_DEBUG", "false").lower() == "true")

--- a/config.py
+++ b/config.py
@@ -8,6 +8,8 @@ class Config:
     SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', default_database_path)
     
     # Secret key for sessions and CSRF
-    SECRET_KEY = "skillswap-dev-secret-key"
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    if not SECRET_KEY:
+        raise ValueError("SECRET_KEY environment variable is not set.")
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
## Summary
- Removed hardcoded SECRET_KEY fallback — app now raises an error if SECRET_KEY is not set in environment variables
- Debug mode no longer hardcoded to True — now controlled via FLASK_DEBUG env variable, defaults to false in production
