### PR TITLE
Fix duplicate nickname crash, broken test routes, and missing JS refe…

### DIFF
--- a/routes/profile.py
+++ b/routes/profile.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, redirect, url_for, request, flash,
 from flask_login import login_required, current_user
 from __init__ import db
 from datetime import datetime
-from models import Skill, normalize_avatar_initials
+from models import Skill, User, normalize_avatar_initials
 
 profile_bp = Blueprint('profile', __name__)
 
@@ -26,7 +26,12 @@ def profile():
 @profile_bp.route('/profile/edit', methods=['POST'])
 @login_required
 def edit_profile():
-    current_user.nickname = request.form.get('nickname', current_user.nickname).strip()
+    new_nickname = request.form.get('nickname', current_user.nickname).strip()
+    if new_nickname != current_user.nickname:
+        if User.query.filter_by(nickname=new_nickname).first():
+            flash('Nickname is already taken.', 'error')
+            return redirect(url_for('profile.profile'))
+    current_user.nickname = new_nickname
     current_user.course = request.form.get('course', current_user.course or '').strip()
     current_user.bio = request.form.get('bio', current_user.bio or '').strip()
     current_user.avatar_initials = normalize_avatar_initials(

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,4 @@
 
 {% endblock %}
 
-{% block scripts %}
-<script src="{{ url_for('static', filename='js/index.js') }}"></script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -176,8 +176,7 @@ class RequestsTests(BaseTestCase):
     # TC7 — send request creates pending entry
     def test_send_request(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
         req = Request.query.filter_by(from_user_id=self.alice.id).first()
         self.assertIsNotNone(req)
         self.assertEqual(req.status, 'pending')
@@ -185,24 +184,20 @@ class RequestsTests(BaseTestCase):
     # TC8 — cannot request own skill
     def test_cannot_request_own_skill(self):
         self.login_as('bob@test.com', 'Pass5678')
-        rv = self.client.post(f'/requests/send/{self.skill.id}',
-                              content_type='application/json')
+        rv = self.client.post('/request_skill', data={'skill_id': self.skill.id})
         self.assertEqual(rv.status_code, 400)
 
     # TC9 — duplicate request rejected
     def test_duplicate_request_rejected(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
-        rv = self.client.post(f'/requests/send/{self.skill.id}',
-                              content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
+        rv = self.client.post('/request_skill', data={'skill_id': self.skill.id})
         self.assertEqual(rv.status_code, 400)
 
     # TC10 — accept request changes status
     def test_accept_request(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
         req = Request.query.filter_by(from_user_id=self.alice.id).first()
         self.client.get('/logout', follow_redirects=True)
 


### PR DESCRIPTION
- Fixed profile edit crashing when a nickname is already taken — now shows a friendly error instead of a server error
- Fixed unit tests that were hitting a deleted route and getting 404s — updated to use the correct endpoint
- Removed a broken JavaScript reference on the landing page that was causing a 404 on every visit