### PR TITLE
Signup connections updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,335 @@
-# Campus Skill Exchange Platform (SkillSwap)
-##for testing
-## Concept
-A university-only platform where students can offer skills they can teach, request skills they want to learn, and connect with other students through simple skill-exchange requests.
+# SkillSwap
+
+**A campus skill-exchange platform for university students.**
+
+SkillSwap helps students discover skills offered by peers, post what they can teach, send exchange requests, and chat once connected — all in one place.
 
 ---
 
-## 1. Project Purpose
-This application addresses a common campus problem: many students have useful skills such as coding, design, languages, music, or public speaking, but there is no centralized platform to exchange those skills.
+## Table of Contents
 
-The platform enables students to:
-- Discover skills offered by peers
-- Share skills they can teach
-- Request to learn new skills from others
-
----
-
-## 2. CSS Framework
-
-**Framework:** Bootstrap  
-
-**Why Bootstrap:**
-- Easy to learn and use
-- Provides ready-made components (forms, cards, navbar, buttons)
-- Helps build responsive UI quickly
-- Ideal for teams with mixed skill levels
-
-
-## 3. User Stories
-### create and access account
-1. As a student, I want to create an account so that I can join the platform.
-2. As a user, I want to log in and log out securely.
-### profile creation
-3. As a student, I want to create a profile with my details.
-### listing and browsing the skills
-4. As a student, I want to list skills I can teach.
-5. As a student, I want to list skills I want to learn.
-6. As a user, I want to browse skills posted by others.
-7. As a user, I want to search or filter skills.
-8. As a user, I want to view detailed skill information.
-### sending the request and approval
-9. As a student, I want to send a skill exchange request.
-10. As a student, I want to receive requests.
-11. As a student, I want to accept or reject requests.
-### CRUD on the post
-12. As a user, I want to edit or delete my posts.
+- [Overview](#overview)
+- [Team Members](#team-members)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Getting Started](#getting-started)
+- [Configuration](#configuration)
+- [Project Structure](#project-structure)
+- [How It Works](#how-it-works)
+- [Running Tests](#running-tests)
+- [Database & Migrations](#database--migrations)
+- [Documentation](#documentation)
+- [License](#license)
 
 ---
 
-## 4. Main Pages
+## Overview
 
-- Home Page
-- Signup Page
-- Login Page
-- Dashboard
-- User Profile Page
-- Browse Skills Page
-- Skill Details Page
-- Create Skill Post Page
-- Edit Skill Post Page
-- Requests Page
-- Search/Filter Results Page
+Many students have valuable skills — programming, design, languages, music, public speaking — but lack a simple way to find and connect with others on campus who want to learn or teach.
+
+SkillSwap solves that by providing:
+
+- A **browse & search** experience for skills posted by other students
+- A **profile** to manage your details and the skills you offer
+- A **request workflow** to ask someone to exchange skills with you
+- **Real-time chat** once a connection is accepted
+
+Built as a Flask web application for the UWA Agile Web Development unit.
 
 ---
 
-## 5. Core Feature
+## Team Members
 
-### Authentication 
-- Signup
-- Login
-- Logout
+| UWA ID | Name | GitHub Username |
+|--------|------|-----------------|
+| 24562775 | Sahil Pankajbhai Patel | [sahilppatel1807](https://github.com/sahilppatel1807) |
+| 25039111 | Nandhukrishna Gujjalapudi | [NandhuKrishna001](https://github.com/NandhuKrishna001) |
+| 24944854 | Qi Ding | [qid7182](https://github.com/qid7182) |
+| 24336969 | Xiaotong Liu | [Karinaaa-Liu](https://github.com/Karinaaa-Liu) |
 
-### Profile
-- Name, Course, Bio
-- Skills offered
-- Skills wanted
+---
 
-### Skill Posts
-- Create skill post
-- Edit/delete post
-- Categorize skill
+## Features
+
+### Authentication & Account
+
+- Sign up with name, nickname, email, password, course, and bio
+- Secure login and logout (password hashing via Werkzeug)
+- Account settings: change password, name, email, or delete account
+- Login rate limiting to reduce brute-force attempts
+
+### Profile & Skills
+
+- Edit profile (name, course, bio)
+- Add, edit, and delete skills you can teach
+- Categorise skills (e.g. Programming, Design, Music)
+- Optional skill level badges (Beginner, Intermediate, Expert)
 
 ### Discovery
-- Browse all skills
-- Search/filter
 
-### Interaction
-- Send request
-- Accept/decline request
+- Browse all skills on the platform
+- Filter by category
+- Search by skill name or description
+
+### Requests & Connections
+
+- Send a skill exchange request from the Browse Skills page
+- View incoming and outgoing requests on the Requests page
+- Accept or decline incoming requests
+- **Person-level connections:** once any request between two users is accepted, you are connected with that person — you can chat with them and all their other skills show as **Accepted** without sending separate requests
+
+### Chat
+
+- Message users you have an accepted connection with
+- Connection sidebar and message history
+- AJAX-based send and load (no page reload)
+
+### Notifications
+
+- Navbar badge for unseen incoming requests and unseen responses on sent requests
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|--------|------------|
+| Backend | [Flask](https://flask.palletsprojects.com/) |
+| ORM | [Flask-SQLAlchemy](https://flask-sqlalchemy.palletsprojects.com/) |
+| Auth | [Flask-Login](https://flask-login.readthedocs.io/) |
+| Forms & CSRF | [Flask-WTF](https://flask-wtf.readthedocs.io/) |
+| Migrations | [Flask-Migrate](https://flask-migrate.readthedocs.io/) (Alembic) |
+| Rate limiting | [Flask-Limiter](https://flask-limiter.readthedocs.io/) |
+| Database | SQLite (default, local `instance/skillswap.db`) |
+| Frontend | Jinja2 templates, custom CSS, [Bootstrap](https://getbootstrap.com/) (modals & layout), [Tabler Icons](https://tabler.io/icons) |
+| Client JS | jQuery (AJAX for requests & chat) |
+| E2E tests | [Selenium](https://www.selenium.dev/) |
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+- `pip`
+- (Optional) Chrome/Chromium for Selenium end-to-end tests
+
+### 1. Enter the project
+
+```bash
+cd Skillswap
+```
+
+### 2. Create a virtual environment
+
+```bash
+python3 -m venv venv
+source venv/bin/activate        # macOS / Linux
+# venv\Scripts\activate         # Windows
+```
+
+### 3. Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 4. Set environment variables
+
+Create a `.env` file in the project root with this fields.
+
+```env
+SECRET_KEY=dev-secret-key
+
+# if you want you can enable the debug mode too.
+FLASK_DEBUG=true
+```
+OR (put this in the CLI)
+```
+export SECRET_KEY=dev-secret-key
+python app.py
+```
+
+`SECRET_KEY` is **required**. The app will not start without it.
+
+### 5. Run the application
+
+```bash
+python app.py
+```
+
+Open [http://127.0.0.1:5000](http://127.0.0.1:5000) in your browser.
+
+On first run, the database is created automatically in `instance/skillswap.db`.
+
+---
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SECRET_KEY` | Yes | — | Flask session signing key |
+| `FLASK_DEBUG` | No | `false` | Enable Flask debug mode (`true` / `false`) |
+| `DATABASE_URL` | No | `sqlite:///…/instance/skillswap.db` | SQLAlchemy database URI |
+
+Configuration is defined in `config.py`. Test configs (`TestConfig`, `SeleniumTestConfig`) use in-memory SQLite and are used only by the test suite.
+
+---
+
+## Project Structure
+
+```
+Skillswap/
+├── app.py                 # Application entry point
+├── __init__.py            # App factory, extensions, blueprints
+├── config.py              # Environment-based configuration
+├── models.py              # User, Skill, Request, Message models
+├── forms.py               # WTForms for auth and settings
+├── routes/
+│   ├── main.py            # Home page
+│   ├── auth.py            # Signup, login, logout, account settings
+│   ├── skills.py          # Browse & post skills
+│   ├── requests.py        # Send, accept, decline requests
+│   ├── profile.py         # Profile & skill CRUD
+│   └── chat.py            # Messaging between connected users
+├── templates/             # Jinja2 HTML templates
+├── static/
+│   ├── css/               # Page-specific stylesheets
+│   └── js/                # skills.js, chat.js, profile.js
+├── migrations/            # Alembic database migrations
+├── tests/
+│   ├── unit_tests.py      # Unit / integration tests
+│   └── selenium_tests.py  # Browser end-to-end tests
+├── docs/
+│   ├── user_stories.md
+│   ├── test_cases.md
+│   ├── test_report.md
+│   └── database_er_diagram.md
+├── instance/              # Local SQLite DB (gitignored)
+└── requirements.txt
+```
+
+---
+
+## How It Works
+
+### Typical user flow
+
+1. **Sign up** and create a profile.
+2. **Add skills** you can teach from your Profile page.
+3. **Browse Skills** to find what others offer — filter by category or search by keyword.
+4. Click **Request** on a skill card to send an exchange request.
+5. The skill owner sees the request under **Requests → Incoming** and can **Accept** or **Decline**.
+6. Once accepted, both users appear in each other's **Chat** connections and can message freely.
+
+### Person-level connections
+
+Requests are stored per skill, but **connections are per person**:
+
+- Accepting **one** request from a user accepts any other **pending** requests between you and that user.
+- On Browse Skills, **all** skills from a connected user display **Accepted**.
+- You cannot send a new request to someone you are already connected with.
+- Chat access is based on whether **any** accepted request exists between two users (in either direction).
+
+This avoids asking the same person multiple times when they list several skills.
+
+### Request statuses
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Waiting for the recipient to respond |
+| `accepted` | Connection established — chat is available |
+| `declined` | Recipient declined the request |
+
+---
+
+## Running Tests
+
+Tests use in-memory SQLite and disable CSRF for simpler HTTP testing.
+
+### Unit tests
+
+```bash
+python -m unittest tests.unit_tests -v
+```
+
+Run a single test class:
+
+```bash
+python -m unittest tests.unit_tests.RequestsTests -v
+python -m unittest tests.unit_tests.ChatTests -v
+```
+
+### Selenium end-to-end tests
+
+Requires Chrome and ChromeDriver available on your `PATH`. The test runner starts Flask on port **5001** automatically.
+
+```bash
+python -m unittest tests.selenium_tests -v
+```
+
+See [`docs/test_cases.md`](docs/test_cases.md) and [`docs/test_report.md`](docs/test_report.md) for the full test catalogue and results.
+
+---
+
+## Database & Migrations
+
+### Default setup
+
+For local development, `python app.py` runs `db.create_all()` and applies lightweight schema patches for existing databases — no manual migration step is required for a fresh clone.
+
+### Alembic migrations (optional)
+
+If you use Flask-Migrate for schema changes:
+
+```bash
+export FLASK_APP=app.py
+flask db upgrade
+```
+
+### Data model
+
+| Model | Purpose |
+|-------|---------|
+| `User` | Student accounts |
+| `Skill` | Skills a user offers to teach |
+| `Request` | Exchange requests (linked to a skill) |
+| `Message` | Chat messages between connected users |
+
+See [`docs/database_er_diagram.md`](docs/database_er_diagram.md) for the ER diagram and relationship details.
+
+---
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [`docs/user_stories.md`](docs/user_stories.md) | User stories and acceptance criteria |
+| [`docs/test_cases.md`](docs/test_cases.md) | Manual and automated test case definitions |
+| [`docs/test_report.md`](docs/test_report.md) | Test execution report |
+| [`docs/database_er_diagram.md`](docs/database_er_diagram.md) | Database schema overview |
+
+---
+
+## Main Routes
+
+| Route | Description |
+|-------|-------------|
+| `/` | Landing page |
+| `/signup`, `/login`, `/logout` | Authentication |
+| `/skills` | Browse, search, and filter skills |
+| `/profile` | View profile and manage your skills |
+| `/requests` | Incoming and sent exchange requests |
+| `/chat` | Messaging with accepted connections |
+| `/settings/*` | Change password, name, email; delete account |
+
+---
+
+## License
+
+This project was developed as coursework for the University of Western Australia (UWA) Agile Web Development unit (CITS3403 / CITS5505).
+
+Copyright © 2026 Sahil Pankajbhai Patel, Nandhukrishna Gujjalapudi, Qi Ding, and Xiaotong Liu.
+
+All rights reserved. This repository is provided for academic assessment purposes. You may not copy, modify, or distribute this work without permission from the authors and UWA, except as required for unit marking.

--- a/config.py
+++ b/config.py
@@ -1,4 +1,7 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 instance_dir = os.path.join(basedir, 'instance')

--- a/docs/test_report.md
+++ b/docs/test_report.md
@@ -1,8 +1,8 @@
 # SkillSwap — Automated Test Report
 
-**Date:** 16 May 2026
-**Python Version:** 3.8.1
-**Framework:** pytest 8.3.5
+**Date:** 17 May 2026  
+**Python Version:** 3.13  
+**Framework:** `unittest` (Python standard library)
 
 ---
 
@@ -10,21 +10,29 @@
 
 | Suite | Total | Passed | Failed | Duration |
 |---|---|---|---|---|
-| Unit Tests (`unit_tests.py`) | 19 | 19 | 0 | 8.28s |
-| Selenium E2E Tests (`selenium_tests.py`) | 10 | 10 | 0 | 37.83s |
-| **Total** | **29** | **29** | **0** | **~46s** |
+| Unit Tests (`unit_tests.py`) | 23 | 23 | 0 | ~5.3s |
+| Selenium E2E Tests (`selenium_tests.py`) | 10 | 10 | 0 | ~15.2s |
+| **Total** | **33** | **33** | **0** | **~21s** |
 
-All 29 automated tests passed. ✅
+All 33 automated tests passed. ✅
+
+### How to reproduce
+
+```bash
+python -m unittest tests.unit_tests -v
+python -m unittest tests.selenium_tests -v   # requires Chrome + ChromeDriver
+```
 
 ---
 
-## Unit Tests — 19 / 19 Pass
+## Unit Tests — 23 / 23 Pass
 
 ### Registration (`RegistrationTests`)
 
 | Test | Description | Result |
 |---|---|---|
 | test_valid_signup | Valid fields register successfully | ✅ Pass |
+| test_non_student_email_rejected | Non-`@student.uwa.edu.au` email blocked | ✅ Pass |
 | test_duplicate_email_rejected | Duplicate email blocked | ✅ Pass |
 | test_duplicate_nickname_rejected | Duplicate nickname blocked | ✅ Pass |
 | test_password_mismatch_rejected | Mismatched confirm password blocked | ✅ Pass |
@@ -51,9 +59,12 @@ All 29 automated tests passed. ✅
 | Test | Description | Result |
 |---|---|---|
 | test_send_request | Request sent with status pending | ✅ Pass |
-| test_accept_request | Request accepted, status updated | ✅ Pass |
-| test_duplicate_request_rejected | Duplicate request blocked | ✅ Pass |
 | test_cannot_request_own_skill | Own skill request blocked | ✅ Pass |
+| test_duplicate_request_rejected | Duplicate request blocked | ✅ Pass |
+| test_accept_request | Request accepted, status updated | ✅ Pass |
+| test_accepting_one_skill_accepts_other_pending_from_same_user | Accepting one request accepts other pending from same user | ✅ Pass |
+| test_connected_user_shows_accepted_on_all_skills | Connected user's skills show Accepted on browse page | ✅ Pass |
+| test_cannot_request_another_skill_when_already_connected | New request blocked when already connected | ✅ Pass |
 
 ### Chat (`ChatTests`)
 
@@ -67,6 +78,8 @@ All 29 automated tests passed. ✅
 ---
 
 ## Selenium E2E Tests — 10 / 10 Pass
+
+Selenium tests start a live Flask server on port **5001** and drive Chrome.
 
 | Test | Description | Result |
 |---|---|---|
@@ -85,11 +98,12 @@ All 29 automated tests passed. ✅
 
 ## Warnings
 
-Two non-critical warnings were raised during the test run, both related to deprecated SQLAlchemy API usage:
+Non-critical warnings may appear during the test run:
 
-> `LegacyAPIWarning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy`
+- **Flask-Limiter:** in-memory rate-limit storage (expected in test/dev).
+- **SQLAlchemy:** `LegacyAPIWarning` for `Query.get()` and `datetime.utcnow()` deprecation.
 
-This does not affect functionality. The affected calls (`User.query.get()`) should be migrated to `db.session.get(User, id)` in a future update.
+These do not affect test outcomes or application behaviour.
 
 ---
 
@@ -97,10 +111,11 @@ This does not affect functionality. The affected calls (`User.query.get()`) shou
 
 | Manual Test Case | Covered by Automated Test |
 |---|---|
-| TC1–TC3 (valid registration) | `test_valid_signup` |
+| TC1–TC3 (valid registration) | `test_valid_signup`, `test_01_valid_signup` |
 | TC8 (duplicate email) | `test_duplicate_email_rejected`, `test_02_duplicate_email_shows_error` |
 | TC9 (duplicate nickname) | `test_duplicate_nickname_rejected` |
 | TC7 (password mismatch) | `test_password_mismatch_rejected` |
+| Non-student email | `test_non_student_email_rejected` |
 | TC15–TC16 (login) | `test_login_with_email`, `test_login_with_nickname`, `test_03_login_valid_credentials` |
 | TC18 (wrong password) | `test_wrong_password_rejected`, `test_04_login_invalid_credentials` |
 | TC28–TC29 (auth redirect) | `test_unauthenticated_redirects`, `test_05_protected_route_redirects` |
@@ -111,6 +126,7 @@ This does not affect functionality. The affected calls (`User.query.get()`) shou
 | TC8 (own skill disabled) | `test_cannot_request_own_skill`, `test_08_own_skill_button_disabled` |
 | TC9 (duplicate request) | `test_duplicate_request_rejected` |
 | TC10 (accept request) | `test_accept_request`, `test_09_accept_request_shows_badge` |
+| Person-level connections | `test_accepting_one_skill_accepts_other_pending_from_same_user`, `test_connected_user_shows_accepted_on_all_skills`, `test_cannot_request_another_skill_when_already_connected` |
 | TC13 (send message) | `test_send_message` |
 | TC14 (empty message) | `test_empty_message_rejected` |
 | TC17 (unconnected chat) | `test_no_connection_rejected` |

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,14 @@
+import re
+
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, TextAreaField
 from wtforms.validators import DataRequired, Email, Length, EqualTo, Regexp, Optional
+
+STUDENT_EMAIL_MESSAGE = (
+    'Please use your Australian student email address (must end with .edu.au).'
+)
+# WTForms Regexp uses re.match (start of string), so the pattern must span the full email.
+STUDENT_EMAIL_REGEX = r'^[^@]+@[^@]+\.edu\.au$'
 
 
 class LoginForm(FlaskForm):
@@ -40,6 +48,7 @@ class SignupForm(FlaskForm):
         validators=[
             DataRequired(message='Email is required.'),
             Email(message='Please enter a valid email address.'),
+            Regexp(STUDENT_EMAIL_REGEX, flags=re.IGNORECASE, message=STUDENT_EMAIL_MESSAGE),
             Length(max=150,message='Email must be 150 characters or fewer.')
         ]
     )

--- a/models.py
+++ b/models.py
@@ -124,6 +124,19 @@ class Request(db.Model):
     )
 
 
+def users_have_accepted_connection(user_a_id, user_b_id):
+    """True if any skill request between the two users has been accepted."""
+    if user_a_id == user_b_id:
+        return False
+    return Request.query.filter(
+        Request.status == 'accepted',
+        db.or_(
+            db.and_(Request.from_user_id == user_a_id, Request.to_user_id == user_b_id),
+            db.and_(Request.from_user_id == user_b_id, Request.to_user_id == user_a_id),
+        ),
+    ).first() is not None
+
+
 # ── Message ───────────────────────────────────────────────────────
 class Message(db.Model):
     __tablename__ = 'messages'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ werkzeug
 email-validator
 beautifulsoup4
 selenium
+python-dotenv

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1,19 +1,13 @@
 from flask import Blueprint, render_template, request, jsonify
 from flask_login import login_required, current_user
 from __init__ import db
-from models import Request, Message
+from models import Request, Message, users_have_accepted_connection
 
 chat_bp = Blueprint('chat', __name__)
 
 
 def has_accepted_connection(user_id):
-    return Request.query.filter(
-        Request.status == 'accepted',
-        (
-            ((Request.from_user_id == current_user.id) & (Request.to_user_id == user_id)) |
-            ((Request.from_user_id == user_id) & (Request.to_user_id == current_user.id))
-        )
-    ).first() is not None
+    return users_have_accepted_connection(current_user.id, user_id)
 
 
 @chat_bp.route('/chat')

--- a/routes/requests.py
+++ b/routes/requests.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, jsonify
 from flask_login import login_required, current_user
 from __init__ import db
-from models import Skill, Request
+from models import Skill, Request, users_have_accepted_connection
 
 requests_bp = Blueprint('requests', __name__)
 
@@ -37,6 +37,8 @@ def request_skill():
     skill = Skill.query.get_or_404(skill_id)
     if skill.user_id == current_user.id:
         return jsonify({'status': 'error', 'message': 'Cannot request own skill'}), 400
+    if users_have_accepted_connection(current_user.id, skill.user_id):
+        return jsonify({'status': 'error', 'message': 'Already connected with this user'}), 400
     existing = Request.query.filter_by(
         skill_id=skill_id, from_user_id=current_user.id, status='pending'
     ).first()
@@ -60,6 +62,17 @@ def accept_request(request_id):
     req.status = 'accepted'
     req.to_user_seen = True
     req.from_user_seen = False
+
+    Request.query.filter(
+        Request.from_user_id == req.from_user_id,
+        Request.to_user_id == req.to_user_id,
+        Request.status == 'pending',
+        Request.id != req.id,
+    ).update(
+        {Request.status: 'accepted', Request.from_user_seen: False},
+        synchronize_session=False,
+    )
+
     db.session.commit()
     if request.is_json:
         return jsonify({'status': 'ok'})

--- a/routes/skills.py
+++ b/routes/skills.py
@@ -24,6 +24,19 @@ def skills():
     skills_list = query.order_by(Skill.created_at.desc()).all()
     user_requests = Request.query.filter_by(from_user_id=current_user.id).all()
     request_map = {req.skill_id: req.status for req in user_requests}
+
+    connected_user_ids = set()
+    for req in Request.query.filter(
+        db.or_(
+            Request.from_user_id == current_user.id,
+            Request.to_user_id == current_user.id,
+        ),
+        Request.status == 'accepted',
+    ):
+        other_id = (
+            req.to_user_id if req.from_user_id == current_user.id else req.from_user_id
+        )
+        connected_user_ids.add(other_id)
     categories = [c[0] for c in db.session.query(Skill.category).distinct().all() if c[0]]
     if not categories:
         categories = ["Programming", "Design", "Music", "Communication"]
@@ -33,7 +46,8 @@ def skills():
                            categories=categories,
                            current_category=category,
                            current_search=search,
-                           request_map=request_map)
+                           request_map=request_map,
+                           connected_user_ids=connected_user_ids)
 
 
 @skills_bp.route('/skills/new', methods=['POST'])

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -37,7 +37,10 @@
       <div class="form-group">
         <label class="form-label">Email</label>
         <input type="email" name="email" class="auth-input"
-               placeholder="jane@campus.edu" required>
+               placeholder="jane@campus.edu.au"
+               pattern="^[^@]+@[^@]+\.edu\.au$"
+               title="Please use your Australian student email address (must end with .edu.au)."
+               required>
       </div>
 
       <div class="form-group">

--- a/templates/skills.html
+++ b/templates/skills.html
@@ -62,6 +62,9 @@
         <p class="skill-author">by {{ skill.owner.display_name }}</p>
 
         {% set status = request_map.get(skill.id) %}
+        {% if skill.user_id in connected_user_ids %}
+        {% set status = 'accepted' %}
+        {% endif %}
         {% if skill.user_id == current_user.id %}
         <button class="btn btn-secondary" disabled>Your Skill</button>
 

--- a/tests/selenium_tests.py
+++ b/tests/selenium_tests.py
@@ -49,11 +49,11 @@ class SkillSwapE2ETests(unittest.TestCase):
         cls.driver.implicitly_wait(5)
 
         # ── Seed two accounts used across all tests ───────────────────────
-        cls._create_user('Alice', 'alice_e2e', 'alice@e2e.com', 'AlicePass1')
-        cls._create_user('Bob',   'bob_e2e',   'bob@e2e.com',   'BobPass1')
+        cls._create_user('Alice', 'alice_e2e', 'alice@e2e.edu.au', 'AlicePass1')
+        cls._create_user('Bob',   'bob_e2e',   'bob@e2e.edu.au',   'BobPass1')
 
         # Bob posts a skill so Alice can request it
-        cls._js_login('bob@e2e.com', 'BobPass1')
+        cls._js_login('bob@e2e.edu.au', 'BobPass1')
         cls.driver.execute_script("""
             var f = document.createElement('form');
             f.method = 'POST'; f.action = '/skills/new';
@@ -110,12 +110,12 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC1 — valid signup redirects to /login
     def test_01_valid_signup(self):
-        self._create_user('New User', 'newuser99', 'new@e2e.com', 'NewPass1')
+        self._create_user('New User', 'newuser99', 'new@e2e.edu.au', 'NewPass1')
         self.assertIn('login', self.driver.current_url)
 
     # TC8 — duplicate email shows error
     def test_02_duplicate_email_shows_error(self):
-        self._create_user('Alice2', 'alice_dup', 'alice@e2e.com', 'AlicePass1')
+        self._create_user('Alice2', 'alice_dup', 'alice@e2e.edu.au', 'AlicePass1')
         error = WebDriverWait(self.driver, 5).until(
             EC.presence_of_element_located((By.CLASS_NAME, 'auth-error'))
         )
@@ -127,14 +127,14 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC15 — correct credentials redirect away from /login
     def test_03_login_valid_credentials(self):
-        self._login('alice@e2e.com', 'AlicePass1')
+        self._login('alice@e2e.edu.au', 'AlicePass1')
         self.assertNotIn('login', self.driver.current_url)
 
     # TC18 — wrong password shows error
     def test_04_login_invalid_credentials(self):
         self.driver.get(BASE + '/login')
         self.driver.execute_script("""
-            document.querySelector('[name=identifier]').value = 'alice@e2e.com';
+            document.querySelector('[name=identifier]').value = 'alice@e2e.edu.au';
             document.querySelector('[name=password]').value = 'WrongPass9';
             document.getElementById('loginForm').submit();
         """)
@@ -155,7 +155,7 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # Skill TC1 — posted skill appears in the browse grid
     def test_06_add_skill_appears_in_grid(self):
-        self._login('alice@e2e.com', 'AlicePass1')
+        self._login('alice@e2e.edu.au', 'AlicePass1')
         self.driver.execute_script("""
             var f = document.createElement('form');
             f.method = 'POST'; f.action = '/skills/new';
@@ -179,7 +179,7 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC7 — request button changes to "Requested" after clicking
     def test_07_send_request_updates_button(self):
-        self._login('alice@e2e.com', 'AlicePass1')
+        self._login('alice@e2e.edu.au', 'AlicePass1')
         self.driver.get(BASE + '/skills')
         WebDriverWait(self.driver, 5).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '.skills-grid'))
@@ -208,7 +208,7 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC8 — own skill shows disabled "Your Skill" button
     def test_08_own_skill_button_disabled(self):
-        self._login('bob@e2e.com', 'BobPass1')
+        self._login('bob@e2e.edu.au', 'BobPass1')
         self.driver.get(BASE + '/skills')
         WebDriverWait(self.driver, 5).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '.skills-grid'))
@@ -225,7 +225,7 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC10 — Bob accepts Alice's request, badge shows "Accepted"
     def test_09_accept_request_shows_badge(self):
-        self._login('bob@e2e.com', 'BobPass1')
+        self._login('bob@e2e.edu.au', 'BobPass1')
         self.driver.get(BASE + '/requests')
         WebDriverWait(self.driver, 5).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, '.btn-accept'))
@@ -244,7 +244,7 @@ class SkillSwapE2ETests(unittest.TestCase):
 
     # TC_C — chat page loads and accepted connection appears in sidebar
     def test_10_chat_page_shows_connection(self):
-        self._login('alice@e2e.com', 'AlicePass1')
+        self._login('alice@e2e.edu.au', 'AlicePass1')
         self.driver.get(BASE + '/chat')
 
         # Connection item should appear after Bob accepted Alice's request

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -59,24 +59,33 @@ class RegistrationTests(BaseTestCase):
     def test_valid_signup(self):
         self.client.post('/signup', data={
             'name': 'Alice Smith', 'nickname': 'alice',
+            'email': 'alice@uwa.edu.au',
+            'password': 'Pass1234', 'confirm_password': 'Pass1234',
+        })
+        self.assertIsNotNone(User.query.filter_by(email='alice@uwa.edu.au').first())
+
+    def test_non_student_email_rejected(self):
+        rv = self.client.post('/signup', data={
+            'name': 'Alice Smith', 'nickname': 'alice',
             'email': 'alice@test.com',
             'password': 'Pass1234', 'confirm_password': 'Pass1234',
         })
-        self.assertIsNotNone(User.query.filter_by(email='alice@test.com').first())
+        self.assertIsNone(User.query.filter_by(email='alice@test.com').first())
+        self.assertIn(b'.edu.au', rv.data)
 
     # TC7 — mismatched passwords rejected
     def test_password_mismatch_rejected(self):
         self.client.post('/signup', data={
-            'name': 'Alice', 'nickname': 'alice', 'email': 'alice@test.com',
+            'name': 'Alice', 'nickname': 'alice', 'email': 'alice@uwa.edu.au',
             'password': 'Pass1234', 'confirm_password': 'Pass9999',
         })
-        self.assertIsNone(User.query.filter_by(email='alice@test.com').first())
+        self.assertIsNone(User.query.filter_by(email='alice@uwa.edu.au').first())
 
     # TC8 — duplicate email rejected
     def test_duplicate_email_rejected(self):
-        make_user()
+        make_user(email='alice@uwa.edu.au')
         rv = self.client.post('/signup', data={
-            'name': 'Alice2', 'nickname': 'alice2', 'email': 'alice@test.com',
+            'name': 'Alice2', 'nickname': 'alice2', 'email': 'alice@uwa.edu.au',
             'password': 'Pass1234', 'confirm_password': 'Pass1234',
         })
         self.assertIn(b'already exists', rv.data)
@@ -85,7 +94,7 @@ class RegistrationTests(BaseTestCase):
     def test_duplicate_nickname_rejected(self):
         make_user()
         rv = self.client.post('/signup', data={
-            'name': 'Alice2', 'nickname': 'alice', 'email': 'other@test.com',
+            'name': 'Alice2', 'nickname': 'alice', 'email': 'other@curtin.edu.au',
             'password': 'Pass1234', 'confirm_password': 'Pass1234',
         })
         self.assertIn(b'already taken', rv.data)
@@ -176,8 +185,7 @@ class RequestsTests(BaseTestCase):
     # TC7 — send request creates pending entry
     def test_send_request(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
         req = Request.query.filter_by(from_user_id=self.alice.id).first()
         self.assertIsNotNone(req)
         self.assertEqual(req.status, 'pending')
@@ -185,24 +193,20 @@ class RequestsTests(BaseTestCase):
     # TC8 — cannot request own skill
     def test_cannot_request_own_skill(self):
         self.login_as('bob@test.com', 'Pass5678')
-        rv = self.client.post(f'/requests/send/{self.skill.id}',
-                              content_type='application/json')
+        rv = self.client.post('/request_skill', data={'skill_id': self.skill.id})
         self.assertEqual(rv.status_code, 400)
 
     # TC9 — duplicate request rejected
     def test_duplicate_request_rejected(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
-        rv = self.client.post(f'/requests/send/{self.skill.id}',
-                              content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
+        rv = self.client.post('/request_skill', data={'skill_id': self.skill.id})
         self.assertEqual(rv.status_code, 400)
 
     # TC10 — accept request changes status
     def test_accept_request(self):
         self.login_as('alice@test.com', 'Pass1234')
-        self.client.post(f'/requests/send/{self.skill.id}',
-                         content_type='application/json')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
         req = Request.query.filter_by(from_user_id=self.alice.id).first()
         self.client.get('/logout', follow_redirects=True)
 
@@ -211,6 +215,60 @@ class RequestsTests(BaseTestCase):
                          content_type='application/json')
         db.session.refresh(req)
         self.assertEqual(req.status, 'accepted')
+
+    def test_accepting_one_skill_accepts_other_pending_from_same_user(self):
+        skill2 = make_skill(user_id=self.bob.id, name='React', category='Programming')
+        self.login_as('alice@test.com', 'Pass1234')
+        self.client.post('/request_skill', data={'skill_id': self.skill.id})
+        self.client.post('/request_skill', data={'skill_id': skill2.id})
+        req1 = Request.query.filter_by(skill_id=self.skill.id).first()
+        req2 = Request.query.filter_by(skill_id=skill2.id).first()
+        self.client.get('/logout', follow_redirects=True)
+
+        self.login_as('bob@test.com', 'Pass5678')
+        self.client.post(f'/requests/accept/{req1.id}')
+        db.session.refresh(req1)
+        db.session.refresh(req2)
+        self.assertEqual(req1.status, 'accepted')
+        self.assertEqual(req2.status, 'accepted')
+
+    def test_connected_user_shows_accepted_on_all_skills(self):
+        skill2 = make_skill(user_id=self.bob.id, name='React', category='Programming')
+        req = Request(
+            skill_id=self.skill.id,
+            from_user_id=self.alice.id,
+            to_user_id=self.bob.id,
+            status='accepted',
+        )
+        pending = Request(
+            skill_id=skill2.id,
+            from_user_id=self.alice.id,
+            to_user_id=self.bob.id,
+            status='pending',
+        )
+        db.session.add_all([req, pending])
+        db.session.commit()
+
+        self.login_as('alice@test.com', 'Pass1234')
+        rv = self.client.get('/skills')
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn(b'Accepted', rv.data)
+        self.assertNotIn(b'Requested', rv.data)
+
+    def test_cannot_request_another_skill_when_already_connected(self):
+        db.session.add(Request(
+            skill_id=self.skill.id,
+            from_user_id=self.alice.id,
+            to_user_id=self.bob.id,
+            status='accepted',
+        ))
+        db.session.commit()
+        skill2 = make_skill(user_id=self.bob.id, name='React', category='Programming')
+
+        self.login_as('alice@test.com', 'Pass1234')
+        rv = self.client.post('/request_skill', data={'skill_id': skill2.id})
+        self.assertEqual(rv.status_code, 400)
+        self.assertIn(b'Already connected', rv.data)
 
 
 # ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

This MR updates signup validation, request/connection behaviour, environment config, tests, and documentation.

## Changes

- Added `python-dotenv` support so `.env` values load from `config.py`.
- Restricted signup emails to Australian `.edu.au` addresses.
- Added client-side signup email pattern and validation message.
- Added person-level connection behaviour:
  - Accepting one request connects the two users.
  - Other pending requests between the same users are accepted.
  - Already-connected users cannot send another request.
  - Skills from connected users show as `Accepted`.
  - Chat connection checks now use shared connection logic.
- Updated unit and Selenium test emails to use `.edu.au`.
- Aligned request tests with the `/request_skill` endpoint.
- Added new unit tests for student email validation and person-level connections.
- Rewrote README and updated the automated test report.

## Testing
Result: 23 tests passed.