### PR TITLE
Fix account deletion redirect and missing landing script

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -165,5 +165,6 @@ def delete_account():
             user = User.query.get(user_id)
             db.session.delete(user)
             db.session.commit()
-            return redirect(url_for('main.index'))
+            flash('Your account has been deleted.', 'success')
+            return redirect(url_for('auth.login'))
     return render_template('settings/delete_account.html', form=form, error=error)

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -41,6 +41,16 @@
   margin-bottom: 20px;
 }
 
+.auth-success {
+  background: #e6f4ea;
+  border: 1px solid #a8d5b5;
+  border-radius: 8px;
+  color: #2d6a4f;
+  font-size: 13px;
+  padding: 10px 14px;
+  margin-bottom: 20px;
+}
+
 /* ── Form Groups ────────────────────────────────────────────── */
 .form-group {
   margin-bottom: 18px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,7 +83,3 @@
 </div>
 
 {% endblock %}
-
-{% block scripts %}
-<script src="{{ url_for('static', filename='js/index.js') }}"></script>
-{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,6 +13,14 @@
       <p class="auth-subtitle">Login to your SkillSwap account.</p>
     </div>
 
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="auth-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
     {% if error %}
     <div class="auth-error">{{ error }}</div>
     {% endif %}


### PR DESCRIPTION

<img width="360" height="325" alt="Screenshot 2026-05-17 at 3 15 28 PM" src="https://github.com/user-attachments/assets/d71a1ac5-5128-49ac-b5ed-3eff7fdccd03" />

## Description
This PR fixes the broken flow after account deletion.

## Changes made:

- Removed the unused static/js/index.js script tag from templates/index.html
- Updated delete_account to redirect to the login page after successful deletion
- Added a success flash message: “Your account has been deleted.”
- Updated the login page to display flashed success messages

## Testing:

- Deleted an account locally
- Confirmed the user lands on the login page
- Confirmed the success message appears
- Confirmed index.js is no longer requested on the landing page